### PR TITLE
Allow diff option to return non-zero exit codes if changes are required

### DIFF
--- a/shfmt.sh
+++ b/shfmt.sh
@@ -6,6 +6,7 @@ set -o pipefail # capture fail exit codes in piped commands
 # set -x          # execution tracing debug messages
 
 indentation=""
+diff=""
 
 while [[ $# -gt 0 ]] && [[ ."$1" = .-*  || ."$1" = .--* ]]; do
     # Get param and value using parameter expansion, splitting on = or " "
@@ -15,6 +16,9 @@ while [[ $# -gt 0 ]] && [[ ."$1" = .-*  || ."$1" = .--* ]]; do
     case "$param" in
         -i | --indent)
             indentation="-i $value"
+            ;;
+        -d)
+            diff="-d"
             ;;
         -*)
             echo "Error: Unknown option: $param" >&2
@@ -28,6 +32,6 @@ done
 
 for file in "$@"; do
     if file "$file" | grep -Pi 'shell script' > /dev/null; then
-        shfmt -l -w $indentation "$file"
+        shfmt -l -w $indentation $diff "$file"
     fi
 done

--- a/shfmt.sh
+++ b/shfmt.sh
@@ -7,6 +7,7 @@ set -o pipefail # capture fail exit codes in piped commands
 
 indentation=""
 diff=""
+ret=0
 
 while [[ $# -gt 0 ]] && [[ ."$1" = .-*  || ."$1" = .--* ]]; do
     # Get param and value using parameter expansion, splitting on = or " "
@@ -32,6 +33,7 @@ done
 
 for file in "$@"; do
     if file "$file" | grep -Pi 'shell script' > /dev/null; then
-        shfmt -l -w $indentation $diff "$file"
+        shfmt -l -w $indentation $diff "$file" || ret=$?
     fi
 done
+exit $ret

--- a/shfmt.sh
+++ b/shfmt.sh
@@ -31,8 +31,11 @@ while [[ $# -gt 0 ]] && [[ ."$1" = .-*  || ."$1" = .--* ]]; do
     esac
 done
 
+command -v file > /dev/null
+command -v grep > /dev/null
+
 for file in "$@"; do
-    if file "$file" | grep -Pi 'shell script' > /dev/null; then
+    if file "$file" | grep -iq 'shell script'; then
         shfmt -l -w $indentation $diff "$file" || ret=$?
     fi
 done


### PR DESCRIPTION
Also, executing commands inside the `if` statement means non-zero exit codes are treated as truth values. (Discovered because my docker image was missing the `file` command and silently not checking any files). Moved the command execution, and removed non-portable grep options.