### PR TITLE
Fix URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Single [pre-commit](http://pre-commit.com/) hook which runs **[shfmt](https://gi
 An example `.pre-commit-config.yaml`:
 
 ```yaml
--   repo: git://github.com/pecigonzalo/pre-commit-fmt
+-   repo: git://github.com/pecigonzalo/pre-commit-shfmt
     sha: master
     hooks:
       -   id: shell-fmt


### PR DESCRIPTION
The example URL was wrong.

```
Updating git://github.com/pecigonzalo/pre-commit-fmt ... An unexpected error has occurred: CalledProcessError: command: ('/usr/local/bin/git', 'fetch', 'origin', 'HEAD', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    fatal: remote error:
      Repository not found.
```