### PR TITLE
Correct grep and example error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     sha: v0.7.1
     hooks:
       -   id: check-yaml

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Single [pre-commit](http://pre-commit.com/) hook which runs **[shfmt](https://gi
 An example `.pre-commit-config.yaml`:
 
 ```yaml
--   repo: git://github.com/pecigonzalo/pre-commit-shfmt
+-   repo: https://github.com/pecigonzalo/pre-commit-shfmt
     sha: master
     hooks:
       -   id: shell-fmt

--- a/shfmt.sh
+++ b/shfmt.sh
@@ -27,7 +27,7 @@ while [[ $# -gt 0 ]] && [[ ."$1" = .-*  || ."$1" = .--* ]]; do
 done
 
 for file in "$@"; do
-    if file "$file" | grep -Pi 'shell script' > /dev/null; then
+    if file "$file" | grep -i 'shell script' > /dev/null; then
         shfmt -l -w $indentation "$file"
     fi
 done


### PR DESCRIPTION
BSD grep, installed in mac and BSD envs, doesn't have `-P` and it raises an error `grep: invalid option -- P`. So I removed.

And I fixed the repo link of the configuration example in README.
ref: https://github.blog/2021-09-01-improving-git-protocol-security-github/
