### PR TITLE
Bump shell-fmt-go dependency to 3.8.0

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -37,7 +37,7 @@
   description: Rewrites all shell scripts to a canonical format.
   language: golang
   additional_dependencies:
-    - mvdan.cc/sh/v3/cmd/shfmt@v3.5.1
+    - mvdan.cc/sh/v3/cmd/shfmt@v3.8.0
   entry: shfmt
   types:
     - file


### PR DESCRIPTION
This PR updates the go dependency to v3.8.0.

Please release a new tag when this is merged, so that auto-updates can be utilized.